### PR TITLE
chore: add `message` and `attachmentOriginalName`to route send message

### DIFF
--- a/dev-swagger-omnichat-api.yaml
+++ b/dev-swagger-omnichat-api.yaml
@@ -4175,9 +4175,15 @@ definitions:
         description: "Tipo da mensagem, o valor padrão é TEXT"
       chatId:
         type: "string"
+      message:
+        type: "string"
+        description: "Texto enviado na mensagem. Obrigatório quando o tipo for TEXT"
       attachmentUrl:
         type: "string"
         description: "Obrigatório quando o tipo for IMAGE, DOCUMENT ou VIDEO"
+      attachmentOriginalName:
+        type: "string"
+        description: "Nome do arquivo, por ex: 'orçamento.pdf'"
       templateId:
         type: "string"
         format: "uuid10"

--- a/swagger-omnichat-api.yaml
+++ b/swagger-omnichat-api.yaml
@@ -4179,9 +4179,15 @@ definitions:
         description: "Tipo da mensagem, o valor padrão é TEXT"
       chatId:
         type: "string"
+      message:
+        type: "string"
+        description: "Texto enviado na mensagem. Obrigatório quando o tipo for TEXT"
       attachmentUrl:
         type: "string"
         description: "Obrigatório quando o tipo for IMAGE, DOCUMENT ou VIDEO"
+      attachmentOriginalName:
+        type: "string"
+        description: "Nome do arquivo, por ex: 'orçamento.pdf'"
       templateId:
         type: "string"
         format: "uuid10"


### PR DESCRIPTION
## Jira

[S3-12794](https://omnichat.atlassian.net/browse/S3-12794)

## Descrição

Adiciona o campo `message` e `attachmentOrignalName` no rota de `send message`.

[S3-12794]: https://omnichat.atlassian.net/browse/S3-12794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ