### PR TITLE
fix: add redoc lib to omnichat assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Omnichat Public API</title>
+    <link rel="stylesheet" href="main.css" />
+  </head>
 
-<head>
-  <meta charset="utf-8">
-  <title>Omnichat Public API</title>
-  <link rel="stylesheet" href="main.css">
-</head>
-
-<body id="home">
-  <redoc spec-url="swagger-omnichat-api.yaml" lazy-rendering untrusted-spec hide-download-button></redoc>
-  <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js">
-  </script>
-
-</body>
-
+  <body id="home">
+    <redoc
+      spec-url="swagger-omnichat-api.yaml"
+      lazy-rendering
+      untrusted-spec
+      hide-download-button
+    ></redoc>
+    <script src="https://assets.omni.chat/api-docs/redoc.standalone.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Jira
N/A

## Descrição
Adiciona lib redoc.standalone ao omnichat assets 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Redoc script to Omnichat-hosted asset and cleans up HTML in `index.html`.
> 
> - **Docs**:
>   - Update `index.html` to load Redoc from `https://assets.omni.chat/api-docs/redoc.standalone.js` instead of the jsDelivr CDN.
>   - Minor HTML cleanup/formatting in head/body and `redoc` tag attributes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e917c3da8c5a4f926a3d9625978ef9894b232190. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->